### PR TITLE
Issue 34: Add `robust_sample` and `nonneg_pred` config flags

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ URL: https://cdcgov.github.io/nowcastNHSN/, https://github.com/CDCgov/nowcastNHS
 BugReports: https://github.com/CDCgov/nowcastNHSN/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Imports:
     baselinenowcast (>= 0.0.0.1000),
     checkmate,
@@ -46,3 +45,4 @@ Suggests:
     withr
 Config/testthat/edition: 3
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,11 @@ nowcasting National Healthcare Safety Network (NHSN) reporting data.
   point nowcasts and `sample_normal()` / `sample_skellam()` sample from them.
 * `get_uncertainty_fns()` selects the matched fit/sample pair for use
   inside the nowcast pipeline.
+* `nowcast_config()` gains opt-in `robust_sample` and `nonneg_pred` flags
+  (both default `FALSE`) that stop failure-prone error distributions such
+  as the Skellam from failing: `robust_sample` widens the variance instead of
+  erroring when `variance <= |pred|`, and `nonneg_pred` clamps negative
+  predicted counts to `0` (#34).
 
 ## Date and reporting helpers
 

--- a/R/config.R
+++ b/R/config.R
@@ -15,6 +15,16 @@
 #'   probabilistic nowcasts.
 #' @param draws Integer. Number of posterior draws for probabilistic nowcasts.
 #'   Default is 1000.
+#' @param robust_sample Logical. If `TRUE`, make the uncertainty sampler robust
+#'   so it can always draw. For the `"skellam"` model this increases the variance
+#'   to the minimum value that yields valid (positive) Poisson rates for the
+#'   given nowcast mean, instead of erroring when `variance <= |pred|` (see
+#'   [sample_skellam()]). No-op for `"normal"` and `"negative_binomial"`, which
+#'   cannot fail this way. Default is `FALSE`.
+#' @param nonneg_pred Logical. If `TRUE`, clamp negative predicted counts in the
+#'   final nowcast to `0`. This guards against draws where the summed revisions
+#'   push the combined count below zero, at the cost of distorting the
+#'   probabilistic model near zero. Default is `FALSE`.
 #' @param location Character. A single location code (e.g., `"ca"`).
 #'   Default is `NULL`, meaning no specific location is set.
 #' @param output_dir Character. Directory path for partitioned parquet output.
@@ -49,6 +59,8 @@ nowcast_config <- function(
   prop_delay = 0.5,
   uncertainty_model = c("negative_binomial", "normal", "skellam"),
   draws = 1000L,
+  robust_sample = FALSE,
+  nonneg_pred = FALSE,
   location = NULL,
   output_dir = NULL
 ) {
@@ -61,6 +73,8 @@ nowcast_config <- function(
   checkmate::assert_number(scale_factor, lower = 0, add = coll)
   checkmate::assert_number(prop_delay, lower = 0, upper = 1, add = coll)
   checkmate::assert_int(draws, lower = 1L, add = coll)
+  checkmate::assert_logical(robust_sample, len = 1, any.missing = FALSE, add = coll)
+  checkmate::assert_logical(nonneg_pred, len = 1, any.missing = FALSE, add = coll)
   if (!is.null(location)) {
     checkmate::assert_character(location, len = 1, add = coll)
   }
@@ -75,6 +89,8 @@ nowcast_config <- function(
     prop_delay = prop_delay,
     uncertainty_model = uncertainty_model,
     draws = as.integer(draws),
+    robust_sample = robust_sample,
+    nonneg_pred = nonneg_pred,
     location = location,
     output_dir = output_dir
   )
@@ -98,6 +114,8 @@ print.nowcast_config <- function(x, ...) {
   cli::cli_li("prop_delay: {.val {x$prop_delay}}")
   cli::cli_li("uncertainty_model: {.val {x$uncertainty_model}}")
   cli::cli_li("draws: {.val {x$draws}}")
+  cli::cli_li("robust_sample: {.val {x$robust_sample %||% FALSE}}")
+  cli::cli_li("nonneg_pred: {.val {x$nonneg_pred %||% FALSE}}")
   cli::cli_li("location: {.val {x$location %||% 'NULL (set at runtime)'}}")
 
   cli::cli_li("output_dir: {.val {x$output_dir %||% 'NULL (no file output)'}}")

--- a/R/config.R
+++ b/R/config.R
@@ -73,8 +73,18 @@ nowcast_config <- function(
   checkmate::assert_number(scale_factor, lower = 0, add = coll)
   checkmate::assert_number(prop_delay, lower = 0, upper = 1, add = coll)
   checkmate::assert_int(draws, lower = 1L, add = coll)
-  checkmate::assert_logical(robust_sample, len = 1, any.missing = FALSE, add = coll)
-  checkmate::assert_logical(nonneg_pred, len = 1, any.missing = FALSE, add = coll)
+  checkmate::assert_logical(
+    robust_sample,
+    len = 1,
+    any.missing = FALSE,
+    add = coll
+  )
+  checkmate::assert_logical(
+    nonneg_pred,
+    len = 1,
+    any.missing = FALSE,
+    add = coll
+  )
   if (!is.null(location)) {
     checkmate::assert_character(location, len = 1, add = coll)
   }

--- a/R/fit_methods.R
+++ b/R/fit_methods.R
@@ -202,6 +202,12 @@ fit_skellam <- function(x, mu, method = "mle") {
 #'
 #' @param model_name Character. One of `"negative_binomial"`, `"normal"`, or
 #'   `"skellam"`.
+#' @param robust_sample Logical. If `TRUE`, the returned `uncertainty_sampler` is
+#'   made robust to invalid distribution parameters where possible. For the
+#'   Skellam model this passes `robust = TRUE` to [sample_skellam()] so that a
+#'   variance <= |pred| widens the variance instead of erroring. No-op for the
+#'   `"normal"` and `"negative_binomial"` models, which cannot fail this way.
+#'   Default is `FALSE`.
 #'
 #' @returns A named list with two elements:
 #'   - `uncertainty_model`: A function for fitting uncertainty parameters
@@ -227,7 +233,8 @@ fit_skellam <- function(x, mu, method = "mle") {
 #' )
 #' }
 get_uncertainty_fns <- function(
-  model_name = c("negative_binomial", "normal", "skellam")
+  model_name = c("negative_binomial", "normal", "skellam"),
+  robust_sample = FALSE
 ) {
   model_name <- match.arg(model_name)
 
@@ -247,7 +254,9 @@ get_uncertainty_fns <- function(
       uncertainty_model = function(obs, pred) {
         baselinenowcast::fit_by_horizon(obs, pred, fit_model = fit_skellam)
       },
-      uncertainty_sampler = sample_skellam
+      uncertainty_sampler = function(pred, uncertainty_params) {
+        sample_skellam(pred, uncertainty_params, robust = robust_sample)
+      }
     )
   )
 }

--- a/R/run_nowcasts.R
+++ b/R/run_nowcasts.R
@@ -267,7 +267,10 @@ run_single_nowcast <- function(
   cumulative = TRUE
 ) {
   # Get uncertainty functions from config
-  uncertainty_fns <- get_uncertainty_fns(config$uncertainty_model)
+  uncertainty_fns <- get_uncertainty_fns(
+    config$uncertainty_model,
+    robust_sample = isTRUE(config$robust_sample)
+  )
 
   # Filter to location
   loc_data <- data |>
@@ -300,6 +303,12 @@ run_single_nowcast <- function(
     uncertainty_model = uncertainty_fns$uncertainty_model,
     uncertainty_sampler = uncertainty_fns$uncertainty_sampler
   )
+
+  # Clamp negative predicted counts to zero if requested
+  if (isTRUE(config$nonneg_pred)) {
+    nowcast_result <- nowcast_result |>
+      dplyr::mutate(pred_count = pmax(.data$pred_count, 0))
+  }
 
   # Add location column
   nowcast_result <- nowcast_result |>

--- a/R/sample_methods.R
+++ b/R/sample_methods.R
@@ -58,6 +58,12 @@ sample_normal <- function(pred, uncertainty_params) {
 #' @param uncertainty_params Vector of variance parameters. Must satisfy
 #'   variance > |pred| for valid Poisson parameters. If length 1, the same
 #'   variance is used for all predictions.
+#' @param robust Logical. If `FALSE` (the default), invalid Skellam parameters
+#'   (variance <= |pred|) raise an error. If `TRUE`, the variance is instead
+#'   bumped up to `|pred| + 1e-6` for the offending entries so that both Poisson
+#'   rates stay positive and sampling can proceed. This preserves the mean
+#'   (`pred`) while widening the variance by the minimal amount needed for valid
+#'   parameters. See the `robust_sample` option of [nowcast_config()].
 #' @returns Integer vector of samples of the same length as `pred`.
 #' @importFrom stats rpois
 #' @importFrom cli cli_abort
@@ -70,13 +76,20 @@ sample_normal <- function(pred, uncertainty_params) {
 #' variance <- 10
 #' samples <- sample_skellam(pred, uncertainty_params = variance)
 #' samples
-sample_skellam <- function(pred, uncertainty_params) {
+sample_skellam <- function(pred, uncertainty_params, robust = FALSE) {
   # Recycle uncertainty_params to match pred length (only length-1 recycling)
   uncertainty_params <- vctrs::vec_recycle(
     uncertainty_params,
     size = length(pred),
     x_arg = "uncertainty_params"
   )
+
+  # In robust mode, widen the variance to the smallest value that keeps both
+  # Poisson rates positive (variance > |pred|). This preserves the mean and
+  # only adjusts entries that would otherwise be invalid.
+  if (robust) {
+    uncertainty_params <- pmax(uncertainty_params, abs(pred) + 1e-6)
+  }
 
   # Compute Poisson parameters
   lambda1 <- 0.5 * (pred + uncertainty_params)

--- a/man/cfa_dataops_source.Rd
+++ b/man/cfa_dataops_source.Rd
@@ -33,8 +33,12 @@ cfa-dataops versions. A temporary directory is used when \code{NULL}.}
 \item{force}{Logical. Passed through to \code{dataops_save --force}.}
 
 \item{run_dataops_save}{Function used to invoke the \code{dataops_save} CLI.
-Defaults to an internal helper that shells out via \code{\link[=system2]{system2()}}. Primarily
-an injection seam for tests; most users should leave the default.}
+The default implementation shells out via \code{\link[=system2]{system2()}}. It is called with
+two arguments: \code{command} (the value of the \code{command} constructor
+argument) and \code{args} (a character vector built from the other
+constructor arguments such as \code{dataset_namespace}, \code{stage}, and
+\code{force}). Override to swap in an alternative runner — for example, a
+different process-spawning mechanism, or a stub during testing.}
 }
 \value{
 A source object of class \code{"cfa_dataops_source"}.

--- a/man/fit_normal.Rd
+++ b/man/fit_normal.Rd
@@ -27,7 +27,7 @@ variance
 }
 \seealso{
 Other estimate_observation_error:
-\code{\link{fit_skellam}()}
+\code{\link[=fit_skellam]{fit_skellam()}}
 }
 \concept{estimate_observation_error}
 \concept{probabilistic_methods}

--- a/man/fit_skellam.Rd
+++ b/man/fit_skellam.Rd
@@ -47,7 +47,7 @@ lambda2 <- 0.5 * (variance - mu_new)
 }
 \seealso{
 Other estimate_observation_error:
-\code{\link{fit_normal}()}
+\code{\link[=fit_normal]{fit_normal()}}
 }
 \concept{estimate_observation_error}
 \concept{probabilistic_methods}

--- a/man/get_uncertainty_fns.Rd
+++ b/man/get_uncertainty_fns.Rd
@@ -4,11 +4,21 @@
 \alias{get_uncertainty_fns}
 \title{Get uncertainty model and sampler functions by name}
 \usage{
-get_uncertainty_fns(model_name = c("negative_binomial", "normal", "skellam"))
+get_uncertainty_fns(
+  model_name = c("negative_binomial", "normal", "skellam"),
+  robust_sample = FALSE
+)
 }
 \arguments{
 \item{model_name}{Character. One of \code{"negative_binomial"}, \code{"normal"}, or
 \code{"skellam"}.}
+
+\item{robust_sample}{Logical. If \code{TRUE}, the returned \code{uncertainty_sampler} is
+made robust to invalid distribution parameters where possible. For the
+Skellam model this passes \code{robust = TRUE} to \code{\link[=sample_skellam]{sample_skellam()}} so that a
+variance <= |pred| widens the variance instead of erroring. No-op for the
+\code{"normal"} and \code{"negative_binomial"} models, which cannot fail this way.
+Default is \code{FALSE}.}
 }
 \value{
 A named list with two elements:

--- a/man/nowcastNHSN-package.Rd
+++ b/man/nowcastNHSN-package.Rd
@@ -20,6 +20,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Sam Brand \email{usi1@cdc.gov}
 
+Authors:
+\itemize{
+  \item Sam Brand \email{usi1@cdc.gov}
+}
+
 Other contributors:
 \itemize{
   \item Dylan Morris \email{dzl1@cdc.gov} [contributor]

--- a/man/nowcast_config.Rd
+++ b/man/nowcast_config.Rd
@@ -10,6 +10,8 @@ nowcast_config(
   prop_delay = 0.5,
   uncertainty_model = c("negative_binomial", "normal", "skellam"),
   draws = 1000L,
+  robust_sample = FALSE,
+  nonneg_pred = FALSE,
   location = NULL,
   output_dir = NULL
 )
@@ -30,6 +32,18 @@ probabilistic nowcasts.}
 
 \item{draws}{Integer. Number of posterior draws for probabilistic nowcasts.
 Default is 1000.}
+
+\item{robust_sample}{Logical. If \code{TRUE}, make the uncertainty sampler robust
+so it can always draw. For the \code{"skellam"} model this increases the variance
+to the minimum value that yields valid (positive) Poisson rates for the
+given nowcast mean, instead of erroring when \verb{variance <= |pred|} (see
+\code{\link[=sample_skellam]{sample_skellam()}}). No-op for \code{"normal"} and \code{"negative_binomial"}, which
+cannot fail this way. Default is \code{FALSE}.}
+
+\item{nonneg_pred}{Logical. If \code{TRUE}, clamp negative predicted counts in the
+final nowcast to \code{0}. This guards against draws where the summed revisions
+push the combined count below zero, at the cost of distorting the
+probabilistic model near zero. Default is \code{FALSE}.}
 
 \item{location}{Character. A single location code (e.g., \code{"ca"}).
 Default is \code{NULL}, meaning no specific location is set.}

--- a/man/sample_normal.Rd
+++ b/man/sample_normal.Rd
@@ -28,7 +28,7 @@ samples
 }
 \seealso{
 Other sample_distribution:
-\code{\link{sample_skellam}()}
+\code{\link[=sample_skellam]{sample_skellam()}}
 }
 \concept{probabilistic_methods}
 \concept{sample_distribution}

--- a/man/sample_skellam.Rd
+++ b/man/sample_skellam.Rd
@@ -4,7 +4,7 @@
 \alias{sample_skellam}
 \title{Sample from a Skellam distribution given predictions and variance}
 \usage{
-sample_skellam(pred, uncertainty_params)
+sample_skellam(pred, uncertainty_params, robust = FALSE)
 }
 \arguments{
 \item{pred}{Vector of predictions (means). Can be negative.}
@@ -12,6 +12,13 @@ sample_skellam(pred, uncertainty_params)
 \item{uncertainty_params}{Vector of variance parameters. Must satisfy
 variance > |pred| for valid Poisson parameters. If length 1, the same
 variance is used for all predictions.}
+
+\item{robust}{Logical. If \code{FALSE} (the default), invalid Skellam parameters
+(variance <= |pred|) raise an error. If \code{TRUE}, the variance is instead
+bumped up to \verb{|pred| + 1e-6} for the offending entries so that both Poisson
+rates stay positive and sampling can proceed. This preserves the mean
+(\code{pred}) while widening the variance by the minimal amount needed for valid
+parameters. See the \code{robust_sample} option of \code{\link[=nowcast_config]{nowcast_config()}}.}
 }
 \value{
 Integer vector of samples of the same length as \code{pred}.
@@ -41,7 +48,7 @@ samples
 }
 \seealso{
 Other sample_distribution:
-\code{\link{sample_normal}()}
+\code{\link[=sample_normal]{sample_normal()}}
 }
 \concept{probabilistic_methods}
 \concept{sample_distribution}

--- a/tests/testthat/test_run_nowcasts.R
+++ b/tests/testthat/test_run_nowcasts.R
@@ -45,6 +45,23 @@ test_that("nowcast_config validates parameters", {
   expect_error(nowcast_config(draws = 0), "draws")
 })
 
+test_that("nowcast_config defaults robust flags to FALSE", {
+  config <- nowcast_config()
+
+  expect_false(config$robust_sample)
+  expect_false(config$nonneg_pred)
+})
+
+test_that("nowcast_config stores and validates robust flags", {
+  config <- nowcast_config(robust_sample = TRUE, nonneg_pred = TRUE)
+
+  expect_true(config$robust_sample)
+  expect_true(config$nonneg_pred)
+
+  expect_error(nowcast_config(robust_sample = "yes"), "robust_sample")
+  expect_error(nowcast_config(nonneg_pred = NA), "nonneg_pred")
+})
+
 test_that("nowcast_config_test creates test configuration", {
   config <- nowcast_config_test()
 
@@ -254,6 +271,47 @@ test_that("run_single_nowcast with skellam uncertainty matches direct call", {
     order(wrapper_result$reference_date, wrapper_result$draw),
   ]
   expect_equal(direct_sorted$pred_count, wrapper_sorted$pred_count)
+})
+
+test_that("run_single_nowcast with nonneg_pred = TRUE clamps negative counts", {
+  skip_if_not_installed("baselinenowcast")
+
+  fixtures <- get_test_fixtures()
+  incremental_data <- fixtures$incremental_data
+
+  nowcast_date <- max(incremental_data$reference_date[
+    incremental_data$location == "ca"
+  ])
+
+  base_args <- list(
+    max_delay = 7,
+    scale_factor = 3,
+    prop_delay = 0.5,
+    uncertainty_model = "skellam",
+    draws = 50
+  )
+
+  set.seed(42)
+  raw <- quietly(run_single_nowcast(
+    data = incremental_data,
+    location = "ca",
+    config = do.call(nowcast_config, c(base_args, list(nonneg_pred = FALSE))),
+    nowcast_date = nowcast_date,
+    cumulative = FALSE
+  ))
+
+  set.seed(42)
+  clamped <- quietly(run_single_nowcast(
+    data = incremental_data,
+    location = "ca",
+    config = do.call(nowcast_config, c(base_args, list(nonneg_pred = TRUE))),
+    nowcast_date = nowcast_date,
+    cumulative = FALSE
+  ))
+
+  # Clamping never produces negative counts and equals pmax(raw, 0) elsewhere
+  expect_true(all(clamped$pred_count >= 0))
+  expect_equal(clamped$pred_count, pmax(raw$pred_count, 0))
 })
 
 # ============================================================================

--- a/tests/testthat/test_sample_methods.R
+++ b/tests/testthat/test_sample_methods.R
@@ -136,6 +136,48 @@ test_that("sample_skellam errors when variance <= |pred|", {
   )
 })
 
+test_that("sample_skellam with robust = TRUE does not error when variance <= |pred|", { # nolint: line_length_linter
+  pred <- c(5)
+  variance <- 4 # Invalid: must be > 5 for non-robust parameters
+
+  expect_no_error(
+    samples <- sample_skellam(pred, uncertainty_params = variance, robust = TRUE)
+  )
+  expect_length(samples, 1)
+  expect_true(all(samples == floor(samples)))
+})
+
+test_that("sample_skellam with robust = TRUE recovers the mean (approx)", {
+  pred <- 5
+  variance <- 4 # Invalid for non-robust; bumped to |pred| + eps when robust
+  n_samples <- 10000
+
+  samples <- withr::with_seed(
+    42,
+    replicate(n_samples, sample_skellam(pred, variance, robust = TRUE))
+  )
+
+  # Bumping the variance preserves the mean (= pred)
+  expect_equal(mean(samples), pred, tolerance = 0.5)
+})
+
+test_that("sample_skellam robust mode leaves valid variances unchanged", {
+  pred <- 5
+  variance <- 20 # Already valid (> |pred|)
+  n_samples <- 5000
+
+  with_robust <- withr::with_seed(
+    42,
+    replicate(n_samples, sample_skellam(pred, variance, robust = TRUE))
+  )
+  without_robust <- withr::with_seed(
+    42,
+    replicate(n_samples, sample_skellam(pred, variance, robust = FALSE))
+  )
+
+  expect_identical(with_robust, without_robust)
+})
+
 test_that("sample_skellam handles negative predictions", {
   pred <- c(-5, -3, -1)
   variance <- 20

--- a/tests/testthat/test_sample_methods.R
+++ b/tests/testthat/test_sample_methods.R
@@ -136,12 +136,17 @@ test_that("sample_skellam errors when variance <= |pred|", {
   )
 })
 
-test_that("sample_skellam with robust = TRUE does not error when variance <= |pred|", { # nolint: line_length_linter
+test_that("sample_skellam with robust = TRUE does not error when variance <= |pred|", {
+  # nolint: line_length_linter
   pred <- c(5)
   variance <- 4 # Invalid: must be > 5 for non-robust parameters
 
   expect_no_error(
-    samples <- sample_skellam(pred, uncertainty_params = variance, robust = TRUE)
+    samples <- sample_skellam(
+      pred,
+      uncertainty_params = variance,
+      robust = TRUE
+    )
   )
   expect_length(samples, 1)
   expect_true(all(samples == floor(samples)))

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -415,6 +415,14 @@ skellam_summary <- nowcast_skellam |>
 print(skellam_summary)
 ```
 
+Because the Skellam (and rounded normal) can sample negative revisions, two failure modes are possible:
+
+  - The Skellam sampler errors when the fitted Skellam `variance` <= the `|pred|` for a particular horizon
+  - A draw whose summed revisions are large and negative can push the combined count below zero.
+
+When running the pipeline through `nowcast_config()`, the opt-in `robust_sample` and `nonneg_pred` flags make these models robust: `robust_sample = TRUE` widens the variance to the smallest value that keeps the Skellam parameters valid (preserving the mean) instead of erroring, and `nonneg_pred = TRUE` clamps any negative predicted count to `0`.
+Both default to `FALSE`, so a failure remains a useful signal to switch to a strictly non-negative model such as the negative binomial unless robustness is explicitly requested.
+
 ### Comparing Uncertainty Models
 
 Let's visualize how the different uncertainty models compare:

--- a/vignettes/state-nowcasts.Rmd
+++ b/vignettes/state-nowcasts.Rmd
@@ -189,6 +189,8 @@ location_configs <- list(
 | `prop_delay` | Proportion of training data for delay estimation | 0.5 |
 | `uncertainty_model` | Error distribution: `"negative_binomial"`, `"normal"`, `"skellam"` | `"negative_binomial"` |
 | `draws` | Number of posterior samples | 1000 |
+| `robust_sample` | Widen the variance instead of erroring when a Skellam draw would have invalid (`variance <= |pred|`) parameters | FALSE |
+| `nonneg_pred` | Clamp negative predicted counts in the nowcast to `0` | FALSE |
 | `location` | Single location code (optional) | NULL |
 | `output_dir` | Directory for parquet output | NULL |
 


### PR DESCRIPTION
Introduce two opt-in nowcast configuration flags: `robust_sample` and `nonneg_pred` (both default FALSE).

This closes #34 .

This pull request introduces two new configuration options to the nowcasting pipeline to improve robustness and flexibility when dealing with error-prone distributions, particularly the Skellam model. The changes allow users to opt into more robust sampling and to clamp negative predicted counts to zero, preventing failures and unrealistic negative predictions. 